### PR TITLE
[RD-76] Pass auth headers to flask

### DIFF
--- a/.ebextensions/02_wsgi_custom.config
+++ b/.ebextensions/02_wsgi_custom.config
@@ -1,0 +1,8 @@
+files:
+  "/etc/httpd/conf.d/wsgi_custom.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      WSGIPassAuthorization On
+


### PR DESCRIPTION
Add custom configuration using .ebextensions to turn on WSGI password authentication, which is off by default in Elastic Beanstalk. This change allows us to retrieve data for the frontend using authentication with the API.