### PR TITLE
[RD-188] Inputs for number inputs return data type as number instead of string

### DIFF
--- a/client/src/views/AuthorIndividualForm.vue
+++ b/client/src/views/AuthorIndividualForm.vue
@@ -129,7 +129,7 @@
             name="author-year-of-birth"
             id="author-year-of-birth"
             type="number"
-            v-model="form.tmpAuthorYearOfBirth"
+            v-model.number="form.tmpAuthorYearOfBirth"
             :disabled="sending"
             @input="updateField()"
           />
@@ -146,7 +146,7 @@
             name="author-year-of-death"
             id="author-year-of-death"
             type="number"
-            v-model="form.tmpAuthorYearOfDeath"
+            v-model.number="form.tmpAuthorYearOfDeath"
             :disabled="sending"
             @input="updateField()"
           />
@@ -256,12 +256,9 @@ export default {
       this.value.authorPseudonym = this.form.tmpAuthorPseudonym
       this.value.authorCitizenship = this.form.tmpAuthorCitizenship
       this.value.domicile = this.form.tmpDomicile
-      this.value.authorYearOfBirth = this.formatInt(this.form.tmpAuthorYearOfBirth)
-      this.value.authorYearOfDeath = this.formatInt(this.form.tmpAuthorYearOfDeath)
+      this.value.authorYearOfBirth = this.form.tmpAuthorYearOfBirth
+      this.value.authorYearOfDeath = this.form.tmpAuthorYearOfDeath
       this.$emit('input', this.value)
-    },
-    formatInt (v) {
-      return (empty(v)) ? null : parseInt(v)
     },
     getValidationClass (fieldName) {
       let field

--- a/client/src/views/CreateCopyrightApplication.vue
+++ b/client/src/views/CreateCopyrightApplication.vue
@@ -67,7 +67,7 @@
                   name="year-completed"
                   id="year-completed"
                   type="number"
-                  v-model="form.yearCompleted"
+                  v-model.number="form.yearCompleted"
                   :disabled="sending"
                   required
                   @blur="validateField('yearCompleted')"
@@ -422,7 +422,7 @@
                   name="possible-rights-and-permissions-phone-number"
                   id="possible-rights-and-permissions-phone-number"
                   autocomplete="tel"
-                  v-model="form.possibleRightsAndPermissionsPhoneNumber"
+                  v-model.number="form.possibleRightsAndPermissionsPhoneNumber"
                   :disabled="sending"
                 />
                 <span
@@ -439,7 +439,7 @@
                   id="possible-rights-and-permissions-phone-number-extension"
                   type="number"
                   autocomplete="tel"
-                  v-model="form.possibleRightsAndPermissionsPhoneNumberExtension"
+                  v-model.number="form.possibleRightsAndPermissionsPhoneNumberExtension"
                   :disabled="sending"
                 />
               </md-field>

--- a/client/tests/unit/views/CreateCopyrightApplication.spec.js
+++ b/client/tests/unit/views/CreateCopyrightApplication.spec.js
@@ -56,7 +56,7 @@ describe('Create Copyright Application', () => {
     expect(_saveCopyrightApplication.called).to.be.true
     const submittedApplication = _saveCopyrightApplication.lastCall.args[0]
     expect(submittedApplication.primaryTitle).to.equal('Zorba')
-    expect(submittedApplication.yearCompleted).to.equal('2020')
+    expect(submittedApplication.yearCompleted).to.equal(2020)
     expect(submittedApplication.authorFirstName).to.equal('Ray')
     expect(submittedApplication.authorLastName).to.equal('Donovan')
     expect(submittedApplication.authorCitizenship).to.equal('GR')


### PR DESCRIPTION
Includes `year completed`, `author year of birth`, `author year of death`, and `phone number`.  Fixes bug where an application, after clicking Save & Return to Homepage, would have some input information missing.