### PR TITLE
[RD-223] Setting numeric field to null when Vue sets it to empty string

### DIFF
--- a/client/src/utils/ValidationHelpers.js
+++ b/client/src/utils/ValidationHelpers.js
@@ -17,3 +17,8 @@ export function mmddyyyy (v) {
     return moment(v, 'MMDDYYYY')._isValid
   }
 }
+
+export function emptyStringToNull (v) {
+  if (v === '') return null
+  else return v
+}

--- a/client/src/views/AuthorForm.vue
+++ b/client/src/views/AuthorForm.vue
@@ -73,7 +73,6 @@ export default {
   },
   methods: {
     updateField () {
-      this.value = this.form
       this.$emit('input', this.form)
     },
     toggleAuthorOrganization () {

--- a/client/src/views/AuthorIndividualForm.vue
+++ b/client/src/views/AuthorIndividualForm.vue
@@ -162,7 +162,7 @@
 <script>
 import { validationMixin } from 'vuelidate'
 import { minValue, maxValue } from 'vuelidate/lib/validators'
-import { empty } from '@/utils/ValidationHelpers'
+import { empty, emptyStringToNull } from '@/utils/ValidationHelpers'
 import CopyrightSelectField from '@/views/CopyrightSelectField'
 
 let d = new Date()
@@ -235,6 +235,8 @@ export default {
   },
   methods: {
     updateField () {
+      this.form.yearOfBirth = emptyStringToNull(this.form.yearOfBirth)
+      this.form.yearOfDeath = emptyStringToNull(this.form.yearOfDeath)
       this.$emit('input', this.form)
     },
     getValidationClass (fieldName) {

--- a/client/src/views/ClaimantForm.vue
+++ b/client/src/views/ClaimantForm.vue
@@ -184,7 +184,6 @@ export default {
   },
   methods: {
     updateField () {
-      this.value = this.form
       this.$emit('input', this.form)
     },
     getValidationClass (fieldName) {

--- a/client/src/views/CreateCopyrightApplication.vue
+++ b/client/src/views/CreateCopyrightApplication.vue
@@ -417,7 +417,7 @@ import {
   maxLength
 } from 'vuelidate/lib/validators'
 import { formatPhoneNumber, isValidPhoneNumber } from '@/utils/PhoneNumberFormatter'
-import { mmddyyyy, empty } from '@/utils/ValidationHelpers'
+import { mmddyyyy, empty, emptyStringToNull } from '@/utils/ValidationHelpers'
 import { removeNonIso8895 } from '@/utils/InvalidCharacters'
 import CopyrightApplicationReview from '@/views/CopyrightApplicationReview'
 import CopyrightSelectField from '@/views/CopyrightSelectField'
@@ -696,6 +696,8 @@ export default {
     Object.keys(this.form).forEach(k => {
       if (k === 'possibleRightsAndPermissionsPhoneNumber') {
         this.form[k] = formatPhoneNumber(this.form[k])
+      } else if (k === 'possibleRightsAndPermissionsPhoneNumberExtension') {
+        this.form[k] = emptyStringToNull(this.form[k])
       } else {
         this.form[k] = removeNonIso8895(this.form[k])
       }


### PR DESCRIPTION
- All optional numeric fields are updated to null when they're an empty string
- The scenario only affects optional fields; it happens when number fields are cleared
- https://github.com/vuejs/vue/issues/7136